### PR TITLE
feat: applied Decorator design pattern

### DIFF
--- a/src/battleships-ui/src/components/MatchDisplay/MapGrid/MapGrid.tsx
+++ b/src/battleships-ui/src/components/MatchDisplay/MapGrid/MapGrid.tsx
@@ -58,15 +58,13 @@ function MapGridTile({
   isSelected,
   disableHover,
 }: MapGridTileProps) {
-  // let shipPartHpString =
-  //   tile.shipPart instanceof ModularShipPart && !isEnemyMap
-  //     ? (tile.shipPart as ModularShipPart).hp.toString()
-  //     : "";
 
-      let shipPartHpString =
+  let shipPartHpString =
     tile.shipPart !== undefined && (tile.shipPart as ModularShipPart).hp && !isEnemyMap
       ? (tile.shipPart as ModularShipPart).hp.toString()
       : "";
+
+  let decoratedShipPart = getText(tile);
 
   return (
     <div
@@ -78,10 +76,24 @@ function MapGridTile({
       onClick={() => onTileSelect(tile)}
     >
       <span className="map-tile-hp-span flex h-full w-full items-center justify-center">
-        {shipPartHpString}
+        {decoratedShipPart || shipPartHpString}
       </span>
     </div>
   );
+
+  function getText(tile: MapTile): string {
+    let currentPart = tile.shipPart;
+
+    while (currentPart) {
+      if ("shipPartName" in currentPart && !isEnemyMap) {
+        return (currentPart as any).shipPartName;
+      }
+      // move to the next decorated layer
+      currentPart = (currentPart as any).decoratedShipPart;
+    }
+
+    return "";
+  }
 
   function getColor(tile: MapTile): string {
     if (isSelected) {

--- a/src/battleships-ui/src/components/MatchDisplay/ShipPlacement/ShipPlacement.tsx
+++ b/src/battleships-ui/src/components/MatchDisplay/ShipPlacement/ShipPlacement.tsx
@@ -258,7 +258,7 @@ export default function ShipPlacement() {
         placerTeam: currentPlayer.team,
         tile: selectedTile,
         alignment: selectedAlignment,
-        ships: currentPlayer.ships,
+        ships: currentPlayer.ships.map(ship => (ship as any).decoratedShip || ship),
       });
     }
     return;

--- a/src/battleships-ui/src/models/Ships/ClassicShips.ts
+++ b/src/battleships-ui/src/models/Ships/ClassicShips.ts
@@ -12,21 +12,21 @@ import { ShipClass } from './ShipClass';
 export interface IClassicShip extends Ship {}
 
 export class ClassicCarrier extends Carrier implements IClassicShip {
-  readonly parts = createParts(5, ShipPartType.Classic, ShipClass.Carrier);
+  readonly parts = createParts(5, ShipPartType.Classic, ShipClass.Carrier, "A", "Red", 5);
 }
 
 export class ClassicBattleship extends Battleship implements IClassicShip {
-  readonly parts = createParts(4, ShipPartType.Classic, ShipClass.Battleship);
+  readonly parts = createParts(4, ShipPartType.Classic, ShipClass.Battleship, "B", "Black", 3);
 }
 
 export class ClassicCruiser extends Cruiser implements IClassicShip {
-  readonly parts = createParts(3, ShipPartType.Classic, ShipClass.Cruiser);
+  readonly parts = createParts(3, ShipPartType.Classic, ShipClass.Cruiser, "C", "Green", 4);
 }
 
 export class ClassicSubmarine extends Submarine implements IClassicShip {
-  readonly parts = createParts(3, ShipPartType.Classic, ShipClass.Submarine);
+  readonly parts = createParts(3, ShipPartType.Classic, ShipClass.Submarine, "D", "Yellow", 5);
 }
 
 export class ClassicSpeedboat extends Speedboat implements IClassicShip {
-  readonly parts = createParts(2, ShipPartType.Classic, ShipClass.Speedboat);
+  readonly parts = createParts(2, ShipPartType.Classic, ShipClass.Speedboat, "E", "White", 3);
 }

--- a/src/battleships-ui/src/models/Ships/ColorShipPartDecorator.ts
+++ b/src/battleships-ui/src/models/Ships/ColorShipPartDecorator.ts
@@ -1,0 +1,15 @@
+import { ShipPart } from "./ShipPart";
+import { ShipPartDecorator } from "./ShipPartDecorator";
+
+export class ColorShipPartDecorator extends ShipPartDecorator {
+  private shipPartColor: string;
+
+  constructor(decoratedShipPart: ShipPart, color: string) {
+    super(decoratedShipPart);
+    this.shipPartColor = color;
+  }
+
+  getPartColor(): string {
+    return this.shipPartColor;
+  }
+}

--- a/src/battleships-ui/src/models/Ships/NamingShipDecorator.ts
+++ b/src/battleships-ui/src/models/Ships/NamingShipDecorator.ts
@@ -1,0 +1,15 @@
+import { ShipDecorator } from './ShipDecorator';
+import Ship from './Ship';
+
+export class NamingShipDecorator<T extends Ship> extends ShipDecorator<T> {
+  private shipName: string;
+
+  constructor(decoratedShip: T, name: string) {
+    super(decoratedShip); // This calls ShipDecorator's constructor, which handles parts
+    this.shipName = name;
+  }
+
+  getName(): string {
+    return this.shipName;
+  }
+}

--- a/src/battleships-ui/src/models/Ships/NamingShipPartDecorator.ts
+++ b/src/battleships-ui/src/models/Ships/NamingShipPartDecorator.ts
@@ -1,0 +1,15 @@
+import { ShipPart } from "./ShipPart";
+import { ShipPartDecorator } from "./ShipPartDecorator";
+
+export class NamingShipPartDecorator extends ShipPartDecorator {
+    private shipPartName: string;
+  
+    constructor(decoratedShipPart: ShipPart, name: string) {
+      super(decoratedShipPart);
+      this.shipPartName = name;
+    }
+  
+    getPartName(): string {
+      return this.shipPartName;
+    } 
+}

--- a/src/battleships-ui/src/models/Ships/Ship.ts
+++ b/src/battleships-ui/src/models/Ships/Ship.ts
@@ -1,4 +1,6 @@
 import Vehicle from '../Vehicle';
+import { ColorShipPartDecorator } from './ColorShipPartDecorator';
+import { NamingShipPartDecorator } from './NamingShipPartDecorator';
 import { ShipClass } from './ShipClass';
 import {
   ClassicShipPart,
@@ -6,6 +8,7 @@ import {
   // ObservingShipPart,
   ShipPart,
 } from './ShipPart';
+import { VisibilityShipPartDecorator } from './VisibilityShipPartDecorator';
 
 export enum ShipPartType {
   Classic,
@@ -16,7 +19,7 @@ export enum ShipPartType {
 export default abstract class Ship extends Vehicle {
   readonly forwardTravelDistance = 1;
   readonly shipClass!: ShipClass;
-  readonly parts!: ShipPart[];
+  abstract readonly parts: ShipPart[];
 }
 
 export abstract class Carrier extends Ship {
@@ -42,15 +45,37 @@ export abstract class Speedboat extends Ship {
 export function createParts(
   amount: number,
   type: ShipPartType,
-  shipClass: ShipClass
+  shipClass: ShipClass,
+  shipPartName: string,
+  shipPartColor: string,
+  shipPartVisibility: number
 ): ShipPart[] {
   const result: ShipPart[] = [];
   
-  result.push(createPart(type, shipClass));
+  // Create the initial decorated part
+  // const basePart = redecorateShipPart(
+  //   new ClassicShipPart(shipClass),
+  //   shipPartName,
+  //   shipPartColor,
+  //   shipPartVisibility
+  // );
+
+  const basePart = createPart(type, shipClass);
+
+  // push the first part and create shallow copies with re-decoration for each part
+  result.push(redecorateShipPart(basePart, shipPartName + 1, shipPartColor, shipPartVisibility));
   for (let i = 1; i < amount; i++) {
-    result.push(result[0].shalowCopy());
+    const copiedPart = basePart.shalowCopy();
+    result.push(redecorateShipPart(copiedPart, shipPartName + (i + 1), shipPartColor, shipPartVisibility));
   }
+  
   return result;
+}
+
+function redecorateShipPart(part: ShipPart, name: string, color: string, visibility: number): ShipPart {
+  const namedPart = new NamingShipPartDecorator(part, name);
+  const coloredPart = new ColorShipPartDecorator(namedPart, color);
+  return new VisibilityShipPartDecorator(coloredPart, visibility);
 }
 
 export function createPart(type: ShipPartType, shipClass: ShipClass) {

--- a/src/battleships-ui/src/models/Ships/ShipDecorator.ts
+++ b/src/battleships-ui/src/models/Ships/ShipDecorator.ts
@@ -1,0 +1,16 @@
+import Ship from './Ship';
+import { ShipPart } from './ShipPart'
+
+export abstract class ShipDecorator<T extends Ship> extends Ship {
+    protected decoratedShip: T;
+
+    constructor(ship: T) {
+        super();
+        this.decoratedShip = ship;
+    }
+
+    get parts(): ShipPart[] {
+        return this.decoratedShip.parts || []; // Fallback to an empty array if parts is undefined
+    }
+
+}

--- a/src/battleships-ui/src/models/Ships/ShipPartDecorator.ts
+++ b/src/battleships-ui/src/models/Ships/ShipPartDecorator.ts
@@ -1,0 +1,19 @@
+import { ShipPart } from "./ShipPart";
+
+// DESIGN PATTERN: Decorator
+export abstract class ShipPartDecorator extends ShipPart {
+    protected decoratedShipPart: ShipPart;
+  
+    constructor(decoratedShipPart: ShipPart) {
+      super(decoratedShipPart.shipClass, decoratedShipPart);
+      this.decoratedShipPart = decoratedShipPart;
+    }
+  
+    public shalowCopy(): ShipPart {
+      return this.decoratedShipPart.shalowCopy();
+    }
+  
+    public deepCopy(): ShipPart {
+      return this.decoratedShipPart.deepCopy();
+    }
+}

--- a/src/battleships-ui/src/models/Ships/VisibilityShipPartDecorator.ts
+++ b/src/battleships-ui/src/models/Ships/VisibilityShipPartDecorator.ts
@@ -1,0 +1,23 @@
+import { ShipPart } from "./ShipPart";
+import { ShipPartDecorator } from "./ShipPartDecorator";
+
+export class VisibilityShipPartDecorator extends ShipPartDecorator {
+  private visibilityLevel: number;
+
+  constructor(decoratedShipPart: ShipPart, visibilityLevel: number) {
+    super(decoratedShipPart);
+    this.visibilityLevel = visibilityLevel;
+  }
+
+  getVisibilityLevel(): number {
+    return this.visibilityLevel;
+  }
+
+  increaseVisibility(amount: number): void {
+    this.visibilityLevel += amount;
+  }
+
+  decreaseVisibility(amount: number): void {
+    this.visibilityLevel = Math.max(0, this.visibilityLevel - amount);
+  }
+}


### PR DESCRIPTION
Applied Decorator design pattern for Ship Part and not Ship because it was more convenient. Because in MapGrid only tile's ShipPart is present and not the whole Ship object.